### PR TITLE
update fs.{read,write}File{,Sync} decls

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -397,32 +397,33 @@ fs.readSync = function(fd, buffer, offset, length, position) {};
 
 /**
  * @param {string} filename
- * @param {string|function(string, *)=}encoding
- * @param {function(string, *)=} callback
+ * @param {string|{encoding:(string|undefined),flag:(string|undefined)}|function(string, (string|buffer.Buffer))=} encodingOrOptions
+ * @param {function(string, (string|buffer.Buffer))=} callback
  */
-fs.readFile = function(filename, encoding, callback) {};
+fs.readFile = function(filename, encodingOrOptions, callback) {};
 
 /**
  * @param {string} filename
- * @param {string=} encoding
+ * @param {string|{encoding:(string|undefined),flag:(string|undefined)}=} encodingOrOptions
+ * @return {string|buffer.Buffer}
  * @nosideeffects
  */
-fs.readFileSync = function(filename, encoding) {};
+fs.readFileSync = function(filename, encodingOrOptions) {};
 
 /**
  * @param {string} filename
  * @param {*} data
- * @param {string|function(string)=} encoding
+ * @param {string|{encoding:(string|undefined),mode:(number|undefined),flag:(string|undefined)}|function(string)=} encodingOrOptions
  * @param {function(string)=} callback
  */
-fs.writeFile = function(filename, data, encoding, callback) {};
+fs.writeFile = function(filename, data, encodingOrOptions, callback) {};
 
 /**
  * @param {string} filename
  * @param {*} data
- * @param {string=} encoding
+ * @param {string|{encoding:(string|undefined),mode:(number|undefined),flag:(string|undefined)}|function(string)=} encodingOrOptions
  */
-fs.writeFileSync = function(filename, data, encoding) {};
+fs.writeFileSync = function(filename, data, encodingOrOptions) {};
 
 /**
  * @param {string} filename


### PR DESCRIPTION
In current (0.10.31) node, these functions take an options object as
their second parameter, not a string.  I'm not sure when this was
changed, although I think it happened many versions ago.

http://nodejs.org/api/fs.html#fs_fs_readfile_filename_options_callback
http://nodejs.org/api/fs.html#fs_fs_readfilesync_filename_options
http://nodejs.org/api/fs.html#fs_fs_writefile_filename_data_options_callback
http://nodejs.org/api/fs.html#fs_fs_writefilesync_filename_data_options

The string form has been left as an alternative for users who are using
old versions of node.

npm test has been run on this commit.
