### PR TITLE
Fixing type annotations in domain.js

### DIFF
--- a/domain.js
+++ b/domain.js
@@ -64,14 +64,14 @@ domain.Domain.prototype.add = function(emitter) {};
 domain.Domain.prototype.remove = function(emitter) {};
 
 /**
- * @param {function(...[*])} callback
- * @return {function(...[*])}
+ * @param {function(...*)} callback
+ * @return {function(...*)}
  */
 domain.Domain.prototype.bind = function(callback) {};
 
 /**
- * @param {function(...[*])} callback
- * @return {function(...[*])}
+ * @param {function(...*)} callback
+ * @return {function(...*)}
  */
 domain.Domain.prototype.intercept = function(callback) {};
 


### PR DESCRIPTION
Fixing the syntax of the type annotations for variable number, any type callbacks to avoid warnings from the Closure Compiler.  Fixes #8.
